### PR TITLE
feat: options pnl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,15 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.34</version>
+			<scope>provided</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/options/Options_Strat/Controller/OptController.java
+++ b/src/main/java/com/options/Options_Strat/Controller/OptController.java
@@ -1,0 +1,20 @@
+package com.options.Options_Strat.Controller;
+
+
+import com.options.Options_Strat.Service.OptionsPnl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+public class OptController {
+    @Autowired
+    OptionsPnl usethis;
+    @PostMapping("/strategy-builder")
+    public double calc(@RequestBody Map<String, Object> frombrowser){
+
+        double result=usethis.calc(frombrowser);
+        return result;
+    }
+}

--- a/src/main/java/com/options/Options_Strat/OptionsStratApplication.java
+++ b/src/main/java/com/options/Options_Strat/OptionsStratApplication.java
@@ -2,8 +2,9 @@ package com.options.Options_Strat;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class })
 public class OptionsStratApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/options/Options_Strat/Service/OptionsPnl.java
+++ b/src/main/java/com/options/Options_Strat/Service/OptionsPnl.java
@@ -1,0 +1,19 @@
+package com.options.Options_Strat.Service;
+
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.Map;
+
+
+@Service
+public class OptionsPnl {
+
+
+    public double calc(@RequestBody Map<String, Object> request){
+        double strikePrice=(double)request.get("strikePrice");
+        System.out.println(strikePrice);
+        return strikePrice;
+    }
+}


### PR DESCRIPTION
Started with the Crypto options pnl calculator feature

Goal is to create a controller , service that takes input of options strike price and premium and calculates the profit and loss based on that.